### PR TITLE
feat: add pr spec to contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,8 @@ Contributing
         * Spaces after `,` and `:`
     * Commits
         * Use the [Conventional Commits](https://www.conventionalcommits.org/) specification when creating commits.
+    * Pull Requests
+        * Pull request titles must use the [Conventional Commits](https://www.conventionalcommits.org/) specification, just like commit names.
 * Name all variables correctly
 * All PRs require at least one successful review from a team member to merge
     * Please do not submit simple PRs like minor readme changes or spelling fixes, unless they are a part of larger changes such as a new feature or bugfix.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,3 +17,5 @@ Contributing
     * Commits
         * Use the [Conventional Commits](https://www.conventionalcommits.org/) specification when creating commits.
 * Name all variables correctly
+* All PRs require at least one successful review from a team member to merge
+    * Please do not submit simple PRs like minor readme changes or spelling fixes, unless they are a part of larger changes such as a new feature or bugfix.


### PR DESCRIPTION
Yes, I am aware of the irony of making a PR to add 2 lines to a text file after just saying that isn't a good idea in the changes to the text file.

Any thoughts on this?