### PR TITLE
fix: logger not replacing parameters

### DIFF
--- a/src/main/java/dev/galacticraft/mod/log/GalacticraftPrependingMessageFactory.java
+++ b/src/main/java/dev/galacticraft/mod/log/GalacticraftPrependingMessageFactory.java
@@ -23,10 +23,7 @@
 package dev.galacticraft.mod.log;
 
 import dev.galacticraft.mod.Constant;
-import org.apache.logging.log4j.message.AbstractMessageFactory;
-import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.message.StringFormattedMessage;
+import org.apache.logging.log4j.message.*;
 
 /**
  * @author <a href="https://github.com/TeamGalacticraft">TeamGalacticraft</a>
@@ -51,56 +48,56 @@ public final class GalacticraftPrependingMessageFactory extends AbstractMessageF
 
     @Override
     public Message newMessage(final String message, final Object... params) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, params);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, params);
     }
 
     @Override
     public Message newMessage(final String message, final Object object) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4, final Object object5) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4, final Object object5, final Object object6) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4, final Object object5, final Object object6, final Object object7) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4, final Object object5, final Object object6, final Object object7, final Object object8) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7, object8);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7, object8);
     }
 
     @Override
     public Message newMessage(final String message, final Object object, final Object object1, final Object object2, final Object object3, final Object object4, final Object object5, final Object object6, final Object object7, final Object object8, final Object object9) {
-        return new StringFormattedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7, object8, object9);
+        return new ParameterizedMessage(Constant.Misc.LOGGER_PREFIX + message, object, object1, object2, object3, object4, object5, object6, object7, object8, object9);
     }
 }


### PR DESCRIPTION
`GalacticraftPrependingMessageFactory` was not replacing parameters in log messages.

Switched from using `StringFormattedMessage` to `ParameterizedMessage`.