### PR TITLE
fix: add on.push to clear warning from CodeQL

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,7 +1,9 @@
 name: Pull Request Check
 on:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
     types: [ synchronize, opened ]
 
 jobs:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,5 +1,6 @@
 name: Pull Request Check
 on:
+  push:
   pull_request:
     types: [ synchronize, opened ]
 


### PR DESCRIPTION
I've noticed that when I setup CodeQL I didn't add the on.push trigger so every pr since then has had a warning such as:
```
1 issue was detected with this workflow: Please specify an on.push hook so that Code Scanning can compare pull requests against the state of the base branch.
```
This PR adds that trigger to fix the warning.

~~More work is needed to reduce the amount of runs.~~ fixed with 168a6d1