### PR TITLE
fix: license headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -282,13 +282,11 @@ publishing {
 }
 
 license {
-    // Just throw a fit about this for now and require this later in development
-    ignoreFailures(true)
     setHeader(project.file("LICENSE_HEADER.txt"))
     include("**/dev/galacticraft/**/*.java")
     include("build.gradle.kts")
     ext {
-        set("year", Year.now().value)
+        set("year", "2022")
         set("company", "Team Galacticraft")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx4G
 # Fabric Info
 minecraft.version=1.17.1
 yarn.build=63
-loader.version=0.11.7
+loader.version=0.12.12
 
 # Mod Info
 mod.version=5.0.0-prealpha

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/gametest/java/dev/galacticraft/mod/gametest/JUnit5XMLTestCompletionListener.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/JUnit5XMLTestCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/mixin/TestServerMixin.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/mixin/TestServerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/GalacticraftGameTest.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/GalacticraftGameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/GalacticraftTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/GalacticraftTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/PipeTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/PipeTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/WireTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/WireTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CircuitFabricatorTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CircuitFabricatorTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CoalGeneratorTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CoalGeneratorTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CompressorTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/CompressorTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricArcFurnaceTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricArcFurnaceTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricCompressorTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricCompressorTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricFurnaceTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/ElectricFurnaceTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/EnergyStorageModuleTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/EnergyStorageModuleTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/MachineGameTest.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/MachineGameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/RefineryTestSuite.java
+++ b/src/gametest/java/dev/galacticraft/mod/gametest/test/machine/RefineryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/Constant.java
+++ b/src/main/java/dev/galacticraft/mod/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/Galacticraft.java
+++ b/src/main/java/dev/galacticraft/mod/Galacticraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/GalacticraftClient.java
+++ b/src/main/java/dev/galacticraft/mod/GalacticraftClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/GalacticraftMixinPlugin.java
+++ b/src/main/java/dev/galacticraft/mod/GalacticraftMixinPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/accessor/ServerWorldAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/accessor/ServerWorldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/accessor/WorldRendererAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/accessor/WorldRendererAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/AbstractDirectionalBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/AbstractDirectionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/AbstractHorizontalDirectionalBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/AbstractHorizontalDirectionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/AutomationType.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/AutomationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/ConfiguredMachineFace.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/ConfiguredMachineFace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/FluidBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/FluidBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/FluidLoggable.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/FluidLoggable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/FluidPipe.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/FluidPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/MachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/MachineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/MultiBlockBase.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/MultiBlockBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/MultiBlockMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/MultiBlockMachineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/MultiBlockPart.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/MultiBlockPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/WireBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/WireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/Colored.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/Colored.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/Connected.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/Connected.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/MachineBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/MachineBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/Pullable.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/Pullable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/SolarPanel.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/SolarPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/Walkway.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/Walkway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/entity/WireBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/entity/WireBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/block/util/BlockFace.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/util/BlockFace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/client/screen/MachineHandledScreen.java
+++ b/src/main/java/dev/galacticraft/mod/api/client/screen/MachineHandledScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/config/Config.java
+++ b/src/main/java/dev/galacticraft/mod/api/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/config/ConfigManager.java
+++ b/src/main/java/dev/galacticraft/mod/api/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/entry/EarthReentryPathfinder.java
+++ b/src/main/java/dev/galacticraft/mod/api/entry/EarthReentryPathfinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/machine/MachineConfiguration.java
+++ b/src/main/java/dev/galacticraft/mod/api/machine/MachineConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/machine/MachineIOConfig.java
+++ b/src/main/java/dev/galacticraft/mod/api/machine/MachineIOConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/machine/MachineStatus.java
+++ b/src/main/java/dev/galacticraft/mod/api/machine/MachineStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/machine/RedstoneInteractionType.java
+++ b/src/main/java/dev/galacticraft/mod/api/machine/RedstoneInteractionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/machine/SecurityInfo.java
+++ b/src/main/java/dev/galacticraft/mod/api/machine/SecurityInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/pipe/Pipe.java
+++ b/src/main/java/dev/galacticraft/mod/api/pipe/Pipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/pipe/PipeConnectionType.java
+++ b/src/main/java/dev/galacticraft/mod/api/pipe/PipeConnectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/pipe/PipeNetwork.java
+++ b/src/main/java/dev/galacticraft/mod/api/pipe/PipeNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/pipe/impl/PipeNetworkImpl.java
+++ b/src/main/java/dev/galacticraft/mod/api/pipe/impl/PipeNetworkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/screen/MachineScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/api/screen/MachineScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/solarpanel/LightSource.java
+++ b/src/main/java/dev/galacticraft/mod/api/solarpanel/LightSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/solarpanel/SolarPanelRegistry.java
+++ b/src/main/java/dev/galacticraft/mod/api/solarpanel/SolarPanelRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/solarpanel/WorldLightSources.java
+++ b/src/main/java/dev/galacticraft/mod/api/solarpanel/WorldLightSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/wire/Wire.java
+++ b/src/main/java/dev/galacticraft/mod/api/wire/Wire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/wire/WireConnectionType.java
+++ b/src/main/java/dev/galacticraft/mod/api/wire/WireConnectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/wire/WireNetwork.java
+++ b/src/main/java/dev/galacticraft/mod/api/wire/WireNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/api/wire/impl/WireNetworkImpl.java
+++ b/src/main/java/dev/galacticraft/mod/api/wire/impl/WireNetworkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/Automatable.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/Automatable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/NullAutomatable.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/NullAutomatable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/energy/InfiniteCapacitor.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/energy/InfiniteCapacitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/energy/WireEnergyInsertable.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/energy/WireEnergyInsertable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/fluid/MachineFluidInv.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/fluid/MachineFluidInv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/fluid/PipeFluidInsertable.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/fluid/PipeFluidInsertable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/item/MachineInvWrapper.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/item/MachineInvWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/item/MachineItemInv.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/item/MachineItemInv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/misc/ArrayReference.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/misc/ArrayReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/attribute/oxygen/InfiniteOxygenTank.java
+++ b/src/main/java/dev/galacticraft/mod/attribute/oxygen/InfiniteOxygenTank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/GalacticraftBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/GalacticraftBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/decoration/GratingBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/decoration/GratingBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/decoration/LightPanelBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/decoration/LightPanelBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/decoration/LunarCartographyTableBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/decoration/LunarCartographyTableBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/decoration/VacuumGlassBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/decoration/VacuumGlassBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/AdvancedSolarPanelBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/AdvancedSolarPanelBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/BasicSolarPanelBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/BasicSolarPanelBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/BubbleDistributorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/BubbleDistributorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/CircuitFabricatorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/CircuitFabricatorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/CoalGeneratorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/CoalGeneratorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/CompressorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/CompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/ElectricArcFurnaceBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/ElectricArcFurnaceBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/ElectricCompressorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/ElectricCompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/ElectricFurnaceBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/ElectricFurnaceBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/EnergyStorageModuleBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/EnergyStorageModuleBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/GalacticraftBlockEntityType.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/GalacticraftBlockEntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/GlassFluidPipeBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/GlassFluidPipeBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/MachineBlockEntityTicker.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/MachineBlockEntityTicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/OxygenCollectorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/OxygenCollectorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/OxygenCompressorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/OxygenCompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/OxygenDecompressorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/OxygenDecompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/OxygenSealerBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/OxygenSealerBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/OxygenStorageModuleBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/OxygenStorageModuleBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/PipeWalkwayBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/PipeWalkwayBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/RecipeMachineBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/RecipeMachineBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/RefineryBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/RefineryBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/SolarPanelPartBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/SolarPanelPartBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/WalkwayBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/WalkwayBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/entity/WireWalkwayBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/entity/WireWalkwayBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/CavernousVineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/CavernousVineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/CrudeOilBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/CrudeOilBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneLanternBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneLanternBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneTorchBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneWallTorchBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/GlowstoneWallTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/MoonBerryBushBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/MoonBerryBushBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/PoisonousCavernousVineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/PoisonousCavernousVineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/ScorchedRockBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/ScorchedRockBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/UnlitLanternBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/UnlitLanternBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/UnlitTorchBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/UnlitTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/UnlitWallTorchBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/UnlitWallTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/environment/VaporSpoutBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/environment/VaporSpoutBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/machine/CoalGeneratorBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/machine/CoalGeneratorBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/machine/OxygenCollectorBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/machine/OxygenCollectorBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/machine/RefineryBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/machine/RefineryBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/machine/SimpleMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/machine/SimpleMachineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/machine/SimpleMultiBlockMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/machine/SimpleMultiBlockMachineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/SolarPanelPartBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/SolarPanelPartBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/TinLadderBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/TinLadderBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier1/AluminumWireBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier1/AluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier1/SealableAluminumWireBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier1/SealableAluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier2/HeavyAluminumWireBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier2/HeavyAluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier2/HeavySealableAluminumWireBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/aluminumwire/tier2/HeavySealableAluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/fluidpipe/GlassFluidPipeBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/fluidpipe/GlassFluidPipeBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/fluidpipe/PipeBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/fluidpipe/PipeBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/walkway/PipeWalkway.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/walkway/PipeWalkway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/walkway/WalkwayBlock.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/walkway/WalkwayBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/block/special/walkway/WireWalkway.java
+++ b/src/main/java/dev/galacticraft/mod/block/special/walkway/WireWalkway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BasicSolarPanelScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BasicSolarPanelScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BubbleDistributorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BubbleDistributorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CircuitFabricatorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CircuitFabricatorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CoalGeneratorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CoalGeneratorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CompressorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricArcFurnaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricArcFurnaceScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricCompressorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricCompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricFurnaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/ElectricFurnaceScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/EnergyStorageModuleScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/EnergyStorageModuleScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/GalacticraftPlayerInventoryScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/GalacticraftPlayerInventoryScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenCollectorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenCollectorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenCompressorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenCompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenDecompressorScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenDecompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenSealerScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenSealerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenStorageModuleScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/OxygenStorageModuleScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/RefineryScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/RefineryScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SolarPanelScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SolarPanelScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/SpaceRaceButtonWidget.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/SpaceRaceButtonWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/AbstractWidget.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/AbstractWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/CapacitorWidget.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/CapacitorWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/Positioned.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/Positioned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/WidgetGroup.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/machine/WidgetGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/DirectionalState.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/DirectionalState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/MachineBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/MachineBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/MachineUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/MachineUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/PipeBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/PipeBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/PipeUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/PipeUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/PipeWalkwayBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/PipeWalkwayBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/PipeWalkwayUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/PipeWalkwayUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WalkwayBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WalkwayBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WalkwayUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WalkwayUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WireBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WireBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WireUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WireUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WireWalkwayBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WireWalkwayBakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/WireWalkwayUnbakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/WireWalkwayUnbakedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/model/entity/EvolvedCreeperEntityModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/entity/EvolvedCreeperEntityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/network/GalacticraftClientPacketReceiver.java
+++ b/src/main/java/dev/galacticraft/mod/client/network/GalacticraftClientPacketReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/block/entity/AdvancedSolarPanelBlockEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/block/entity/AdvancedSolarPanelBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/block/entity/BasicSolarPanelBlockEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/block/entity/BasicSolarPanelBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/block/entity/FluidPipeBlockEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/block/entity/FluidPipeBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/block/entity/GalacticraftBlockEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/block/entity/GalacticraftBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/dimension/EmptyCloudRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/dimension/EmptyCloudRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/dimension/EmptyWeatherRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/dimension/EmptyWeatherRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/dimension/MoonDimensionEffects.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/dimension/MoonDimensionEffects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/dimension/MoonSkyRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/dimension/MoonSkyRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/BubbleEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/BubbleEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedCreeperEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedCreeperEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedEvokerEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedEvokerEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedPillagerEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedPillagerEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedSkeletonEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedSkeletonEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedSpiderEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedSpiderEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedVindicatorEntityRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedVindicatorEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedZombieRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/EvolvedZombieRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/feature/EvolvedCreeperChargeFeatureRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/feature/EvolvedCreeperChargeFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/feature/EvolvedSpiderEyesFeatureRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/feature/EvolvedSpiderEyesFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/feature/SpaceGearFeatureRenderer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/feature/SpaceGearFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/model/GalacticraftEntityModelLayer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/model/GalacticraftEntityModelLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/resource/GalacticraftResourceReloadListener.java
+++ b/src/main/java/dev/galacticraft/mod/client/resource/GalacticraftResourceReloadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/util/CachingSpriteAtlas.java
+++ b/src/main/java/dev/galacticraft/mod/client/util/CachingSpriteAtlas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/client/util/SpriteUtil.java
+++ b/src/main/java/dev/galacticraft/mod/client/util/SpriteUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/command/GalacticraftCommand.java
+++ b/src/main/java/dev/galacticraft/mod/command/GalacticraftCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/modmenu/ModMenuApiImpl.java
+++ b/src/main/java/dev/galacticraft/mod/compat/modmenu/ModMenuApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/client/GalacticraftREIClientPlugin.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/client/GalacticraftREIClientPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/client/category/BaseWidget.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/client/category/BaseWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/client/category/DefaultCompressingCategory.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/client/category/DefaultCompressingCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/client/category/DefaultFabricationCategory.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/client/category/DefaultFabricationCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/GalacticraftREIServerPlugin.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/GalacticraftREIServerPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultCompressingDisplay.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultFabricationDisplay.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultFabricationDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultShapedCompressingDisplay.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultShapedCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultShapelessCompressingDisplay.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/display/DefaultShapelessCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/FabricationMenuInfo.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/FabricationMenuInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/SimpleMachineMenuInfo.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/SimpleMachineMenuInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/stack/LBASlotAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/compat/rei/common/transfer/info/stack/LBASlotAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/compat/waila/GalacticraftWailaPlugin.java
+++ b/src/main/java/dev/galacticraft/mod/compat/waila/GalacticraftWailaPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/config/ConfigImpl.java
+++ b/src/main/java/dev/galacticraft/mod/config/ConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/config/ConfigManagerImpl.java
+++ b/src/main/java/dev/galacticraft/mod/config/ConfigManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/BubbleEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/BubbleEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedCreeperEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedCreeperEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedEvokerEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedEvokerEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedPillagerEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedPillagerEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedSkeletonEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedSkeletonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedSpiderEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedSpiderEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedVindicatorEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedVindicatorEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/EvolvedZombieEntity.java
+++ b/src/main/java/dev/galacticraft/mod/entity/EvolvedZombieEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/GalacticraftEntityType.java
+++ b/src/main/java/dev/galacticraft/mod/entity/GalacticraftEntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/damage/GalacticraftDamageSource.java
+++ b/src/main/java/dev/galacticraft/mod/entity/damage/GalacticraftDamageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/entity/data/GalacticraftTrackedDataHandler.java
+++ b/src/main/java/dev/galacticraft/mod/entity/data/GalacticraftTrackedDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/fluid/BasicFluid.java
+++ b/src/main/java/dev/galacticraft/mod/fluid/BasicFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/fluid/CrudeOilFluid.java
+++ b/src/main/java/dev/galacticraft/mod/fluid/CrudeOilFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/fluid/FuelFluid.java
+++ b/src/main/java/dev/galacticraft/mod/fluid/FuelFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/fluid/GalacticraftFluid.java
+++ b/src/main/java/dev/galacticraft/mod/fluid/GalacticraftFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/fluid/OxygenFluid.java
+++ b/src/main/java/dev/galacticraft/mod/fluid/OxygenFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/AccessoryItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/AccessoryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/BatteryItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/BatteryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/BrittleSwordItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/BrittleSwordItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/CannedFoodItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/CannedFoodItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/FrequencyModuleItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/FrequencyModuleItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/GalacticraftArmorMaterial.java
+++ b/src/main/java/dev/galacticraft/mod/item/GalacticraftArmorMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/GalacticraftFoodComponent.java
+++ b/src/main/java/dev/galacticraft/mod/item/GalacticraftFoodComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/GalacticraftItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/GalacticraftItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/GalacticraftToolMaterial.java
+++ b/src/main/java/dev/galacticraft/mod/item/GalacticraftToolMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/GenericLiquidCanister.java
+++ b/src/main/java/dev/galacticraft/mod/item/GenericLiquidCanister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/HotThrowableMeteorChunkItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/HotThrowableMeteorChunkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/InfiniteBatteryItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/InfiniteBatteryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/OxygenGearItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/OxygenGearItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/OxygenMaskItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/OxygenMaskItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/OxygenTankItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/OxygenTankItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/SchematicItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/SchematicItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/StandardWrenchItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/StandardWrenchItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/ThermalArmorItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/ThermalArmorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/item/ThrowableMeteorChunkItem.java
+++ b/src/main/java/dev/galacticraft/mod/item/ThrowableMeteorChunkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/log/GalacticraftPrependingMessageFactory.java
+++ b/src/main/java/dev/galacticraft/mod/log/GalacticraftPrependingMessageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/loot/GalacticraftLootTable.java
+++ b/src/main/java/dev/galacticraft/mod/loot/GalacticraftLootTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/misc/IntPair.java
+++ b/src/main/java/dev/galacticraft/mod/misc/IntPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/misc/banner/GalacticraftBannerPattern.java
+++ b/src/main/java/dev/galacticraft/mod/misc/banner/GalacticraftBannerPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/misc/cape/CapesLoader.java
+++ b/src/main/java/dev/galacticraft/mod/misc/cape/CapesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/AbstractSkeletonEntityAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/AbstractSkeletonEntityAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/BucketItemAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/BucketItemAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/BuiltinBiomesAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/BuiltinBiomesAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/DamageSourceAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/DamageSourceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/EntityMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/EntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/ExtendedScreenHandlerTypeAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/ExtendedScreenHandlerTypeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/FlowableFluidMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/FlowableFluidMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/ItemStackMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/LanternBlockMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/LanternBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/LootTablesAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/LootTablesAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/ServerWorldMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/ServerWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/SlotAccessor.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/SlotAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/StructurePoolGeneratorMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/StructurePoolGeneratorMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/TorchBlockMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/TorchBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/AbstractClientPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/AlphaWarningTitleScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/AlphaWarningTitleScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/AnimalModelInvoker.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/AnimalModelInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/ClientWorldMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/ClientWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/InGameHudMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/InGameHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/PauseMenuScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/PauseMenuScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/PlayerInventoryScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/PlayerInventoryScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/VillagerEntityRendererMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/VillagerEntityRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/VillagerResemblingModelMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/VillagerResemblingModelMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/WorldRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/mixin/client/WorldRendererOverworldMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/WorldRendererOverworldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/network/GalacticraftServerPacketReceiver.java
+++ b/src/main/java/dev/galacticraft/mod/network/GalacticraftServerPacketReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/particle/GalacticraftParticle.java
+++ b/src/main/java/dev/galacticraft/mod/particle/GalacticraftParticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/particle/fluid/DrippingCrudeOilParticle.java
+++ b/src/main/java/dev/galacticraft/mod/particle/fluid/DrippingCrudeOilParticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/particle/fluid/DrippingFuelParticle.java
+++ b/src/main/java/dev/galacticraft/mod/particle/fluid/DrippingFuelParticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/CompressingRecipe.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/CompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/FabricationRecipe.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/FabricationRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/GalacticraftRecipe.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/GalacticraftRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/GalacticraftRecipeType.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/GalacticraftRecipeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/ShapedCompressingRecipe.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/ShapedCompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/recipe/ShapelessCompressingRecipe.java
+++ b/src/main/java/dev/galacticraft/mod/recipe/ShapelessCompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/BubbleDistributorScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/BubbleDistributorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/CoalGeneratorScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/CoalGeneratorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/CompressorScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/CompressorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/GalacticraftPlayerInventoryScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/GalacticraftPlayerInventoryScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/GalacticraftScreenHandlerType.java
+++ b/src/main/java/dev/galacticraft/mod/screen/GalacticraftScreenHandlerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/OxygenCollectorScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/OxygenCollectorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/RecipeMachineScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/RecipeMachineScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/SimpleMachineScreenHandler.java
+++ b/src/main/java/dev/galacticraft/mod/screen/SimpleMachineScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/factory/MachineScreenHandlerFactory.java
+++ b/src/main/java/dev/galacticraft/mod/screen/factory/MachineScreenHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/factory/RecipeMachineScreenHandlerFactory.java
+++ b/src/main/java/dev/galacticraft/mod/screen/factory/RecipeMachineScreenHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/factory/SimpleMachineScreenHandlerFactory.java
+++ b/src/main/java/dev/galacticraft/mod/screen/factory/SimpleMachineScreenHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/property/CapacitorProperty.java
+++ b/src/main/java/dev/galacticraft/mod/screen/property/CapacitorProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/property/FluidTankPropertyDelegate.java
+++ b/src/main/java/dev/galacticraft/mod/screen/property/FluidTankPropertyDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/property/StatusProperty.java
+++ b/src/main/java/dev/galacticraft/mod/screen/property/StatusProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/AccessorySlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/AccessorySlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/ChargeSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/ChargeSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/FilteredSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/FilteredSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/IconSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/IconSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/ItemSpecificSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/ItemSpecificSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/MachineComponent.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/MachineComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/MachineSlotComponent.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/MachineSlotComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/OutputSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/OutputSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/OxygenTankSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/OxygenTankSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/RecipeInputSlot.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/RecipeInputSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/slot/SlotType.java
+++ b/src/main/java/dev/galacticraft/mod/screen/slot/SlotType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/tank/NullTank.java
+++ b/src/main/java/dev/galacticraft/mod/screen/tank/NullTank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/tank/OxygenTank.java
+++ b/src/main/java/dev/galacticraft/mod/screen/tank/OxygenTank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/screen/tank/Tank.java
+++ b/src/main/java/dev/galacticraft/mod/screen/tank/Tank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/solarpanel/GalacticraftLightSource.java
+++ b/src/main/java/dev/galacticraft/mod/solarpanel/GalacticraftLightSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/sound/GalacticraftSound.java
+++ b/src/main/java/dev/galacticraft/mod/sound/GalacticraftSound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/structure/GalacticraftStructure.java
+++ b/src/main/java/dev/galacticraft/mod/structure/GalacticraftStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/structure/MoonRuinsGenerator.java
+++ b/src/main/java/dev/galacticraft/mod/structure/MoonRuinsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/tag/GalacticraftTag.java
+++ b/src/main/java/dev/galacticraft/mod/tag/GalacticraftTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/ColorUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/ColorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/ConnectingBlockUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/ConnectingBlockUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/DrawableUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/DrawableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/EnergyUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/EnergyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/FluidUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/FluidUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/MultiBlockUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/MultiBlockUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/util/OxygenTankUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/OxygenTankUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/village/GalacticraftTradeOffer.java
+++ b/src/main/java/dev/galacticraft/mod/village/GalacticraftTradeOffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/village/GalacticraftVillagerProfession.java
+++ b/src/main/java/dev/galacticraft/mod/village/GalacticraftVillagerProfession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/village/MoonVillagerType.java
+++ b/src/main/java/dev/galacticraft/mod/village/MoonVillagerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/GalacticraftBiome.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/GalacticraftBiome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/layer/MoonBiomeLayer.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/layer/MoonBiomeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonBaseBiomeLayer.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonBaseBiomeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonBiomeLevelLayer.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonBiomeLevelLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonEdgeBiomeLayer.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonEdgeBiomeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonInnerLayer.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/layer/moon/MoonInnerLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/source/GalacticraftBiomeSource.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/source/GalacticraftBiomeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/biome/source/MoonBiomeSource.java
+++ b/src/main/java/dev/galacticraft/mod/world/biome/source/MoonBiomeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/dimension/GalacticraftDimension.java
+++ b/src/main/java/dev/galacticraft/mod/world/dimension/GalacticraftDimension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/dimension/GalacticraftGas.java
+++ b/src/main/java/dev/galacticraft/mod/world/dimension/GalacticraftGas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/carver/CraterCarver.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/carver/CraterCarver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/carver/GalacticraftCarver.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/carver/GalacticraftCarver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/carver/LunarCaveCarver.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/carver/LunarCaveCarver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/carver/config/CraterCarverConfig.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/carver/config/CraterCarverConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/chunk/GalacticraftChunkGenerator.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/chunk/GalacticraftChunkGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/chunk/MoonChunkGenerator.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/chunk/MoonChunkGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/feature/GalacticraftFeature.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/feature/GalacticraftFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/feature/MoonPillagerBaseFeature.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/feature/MoonPillagerBaseFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/feature/MoonRuinsFeature.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/feature/MoonRuinsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/spawner/EvolvedPillagerSpawner.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/spawner/EvolvedPillagerSpawner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/BlockStateWithChance.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/BlockStateWithChance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/GalacticraftSurfaceBuilder.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/GalacticraftSurfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MoonSurfaceBuilder.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MoonSurfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MultiBlockSurfaceBuilder.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MultiBlockSurfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MultiBlockSurfaceConfig.java
+++ b/src/main/java/dev/galacticraft/mod/world/gen/surfacebuilder/MultiBlockSurfaceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/dev/galacticraft/mod/world/poi/GalacticraftPointOfInterestType.java
+++ b/src/main/java/dev/galacticraft/mod/world/poi/GalacticraftPointOfInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/dev/galacticraft/mod/test/TestTemplate.java
+++ b/src/test/java/dev/galacticraft/mod/test/TestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Team Galacticraft
+ * Copyright (c) 2019-2022 Team Galacticraft
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hardcodes the year so that we don't have failing builds at the beginning of every year
Bumps Fabric Loader and Gradle