### PR TITLE
Zombie learns how to wear a mask; and slow down time

### DIFF
--- a/src/main/java/dev/galacticraft/mod/client/gui/overlay/CountdownOverylay.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/overlay/CountdownOverylay.java
@@ -32,14 +32,14 @@ public class CountdownOverylay {
     public static void renderCountdown(PoseStack poseStack, float tickDelta) {
         Minecraft mc = Minecraft.getInstance();
         if (mc.player.getVehicle() instanceof RocketEntity rocket && rocket.getStage() == LaunchStage.IGNITED) {
-            int count = rocket.getTimeAsState() / 2;
-
-            count = (int) Math.floor(count / 10.0F);
+            int count = (int) Math.floor(((float) rocket.getTimeAsState()) / 20.0f);
 
             final int width = mc.getWindow().getGuiScaledWidth();
             final int height = mc.getWindow().getGuiScaledHeight();
 
             poseStack.pushPose();
+
+            count = 20 - count;
 
             if (count <= 10) {
                 poseStack.scale(4.0F, 4.0F, 0.0F);

--- a/src/main/java/dev/galacticraft/mod/client/render/entity/feature/SpaceGearRenderLayer.java
+++ b/src/main/java/dev/galacticraft/mod/client/render/entity/feature/SpaceGearRenderLayer.java
@@ -24,6 +24,8 @@ package dev.galacticraft.mod.client.render.entity.feature;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Quaternion;
+import com.mojang.math.Vector3f;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.mixin.client.AnimalModelAgeableListModel;
 import net.minecraft.client.model.*;
@@ -103,10 +105,13 @@ public class SpaceGearRenderLayer<T extends Entity, M extends EntityModel<T>> ex
     public void render(PoseStack matrices, MultiBufferSource vertexConsumers, int light, T entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch) {
         VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderType.entityCutoutNoCull(this.getTextureLocation(entity), true));
         if (mask != null) {
-            this.mask.yRot = headYaw;
-            this.mask.xRot = headPitch;
-            this.mask.render(matrices, vertexConsumer, light, OverlayTexture.NO_OVERLAY);
+            matrices.pushPose();
+            matrices.mulPose(new Quaternion(Vector3f.YP, headYaw, true));
+            matrices.mulPose(new Quaternion(Vector3f.XP, headPitch, true));
+            mask.render(matrices, vertexConsumer, light, OverlayTexture.NO_OVERLAY);
+            matrices.popPose();
         }
+
         if (this.tank != null) {
             assert this.pipe != null;
             this.tank.render(matrices, vertexConsumer, light, OverlayTexture.NO_OVERLAY);

--- a/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
@@ -1,0 +1,34 @@
+package dev.galacticraft.mod.mixin;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.OptionalLong;
+
+@Mixin(DimensionType.class)
+public class DimensionTypeMixin {
+    @Unique private boolean isMoon;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void gc$initDimType(OptionalLong optionalLong, boolean bl, boolean bl2, boolean bl3, boolean bl4, double d, boolean bl5, boolean bl6, int i, int j, int k, TagKey tagKey, ResourceLocation resourceLocation, float f, DimensionType.MonsterSettings monsterSettings, CallbackInfo ci) {
+        isMoon = resourceLocation.getPath().contains("moon");
+    }
+
+    @ModifyVariable(method = "timeOfDay", at = @At("HEAD"), index = 1, argsOnly = true)
+    private long changeTime(long value) {
+        if (isMoon) {
+            return value / 16;
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/DimensionTypeMixin.java
@@ -1,5 +1,6 @@
 package dev.galacticraft.mod.mixin;
 
+import dev.galacticraft.mod.world.dimension.GCDimensionType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.dimension.DimensionType;
@@ -20,7 +21,7 @@ public class DimensionTypeMixin {
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void gc$initDimType(OptionalLong optionalLong, boolean bl, boolean bl2, boolean bl3, boolean bl4, double d, boolean bl5, boolean bl6, int i, int j, int k, TagKey tagKey, ResourceLocation resourceLocation, float f, DimensionType.MonsterSettings monsterSettings, CallbackInfo ci) {
-        isMoon = resourceLocation.getPath().contains("moon");
+        isMoon = resourceLocation.equals(GCDimensionType.MOON_KEY.location());
     }
 
     @ModifyVariable(method = "timeOfDay", at = @At("HEAD"), index = 1, argsOnly = true)

--- a/src/main/resources/galacticraft.mixins.json
+++ b/src/main/resources/galacticraft.mixins.json
@@ -13,6 +13,7 @@
     "FlowingFluidMixin",
     "ItemStackMixin",
     "LanternBlockMixin",
+    "DimensionTypeMixin",
     "LivingEntityMixin",
     "ModelProviderMixin",
     "PlayerMixin",


### PR DESCRIPTION
New: Moon time is slowed down by 16x. The cryogenic chamber will need some special math to accommodate for this change.

Fix: Countdown in rockets works properly, and mobs now wear oxygen masks properly.