### PR TITLE
hotfix: Registering fluid variants attributes after blocks

### DIFF
--- a/src/main/java/dev/galacticraft/mod/Galacticraft.java
+++ b/src/main/java/dev/galacticraft/mod/Galacticraft.java
@@ -64,6 +64,7 @@ public class Galacticraft implements ModInitializer {
         GCTags.register();
         GCFluids.register();
         GCBlocks.register();
+        GCFluids.registerFluidVariantAttributes(); // Must be called after GCBlocks.register() so that grates can work
         GCBlockEntityTypes.register();
         GCItems.register();
         GCCreativeModeTabs.register();

--- a/src/main/java/dev/galacticraft/mod/content/GCFluids.java
+++ b/src/main/java/dev/galacticraft/mod/content/GCFluids.java
@@ -52,22 +52,24 @@ public class GCFluids {
         register(Constant.Fluid.FUEL_STILL, FUEL);
         register(Constant.Fluid.FUEL_FLOWING, FLOWING_FUEL);
         register(Constant.Fluid.LIQUID_OXYGEN, LIQUID_OXYGEN);
+    }
 
+    public static void registerFluidVariantAttributes() {
         FluidVariantAttributes.register(CRUDE_OIL, new GCFluidAttribute(
                 Component.translatable(GCBlocks.CRUDE_OIL.getDescriptionId())
-                    .setStyle(Constant.Text.Color.DARK_GRAY_STYLE),
+                        .setStyle(Constant.Text.Color.DARK_GRAY_STYLE),
                 FluidConstants.LAVA_VISCOSITY,
                 false
         ));
         FluidVariantAttributes.register(FUEL, new GCFluidAttribute(
                 Component.translatable(GCBlocks.FUEL.getDescriptionId())
-                    .setStyle(Constant.Text.Color.YELLOW_STYLE),
+                        .setStyle(Constant.Text.Color.YELLOW_STYLE),
                 2000,
                 false
         ));
         FluidVariantAttributes.register(LIQUID_OXYGEN, new GCFluidAttribute(
                 Component.translatable("block.galacticraft.oxygen")
-                    .setStyle(Constant.Text.Color.AQUA_STYLE),
+                        .setStyle(Constant.Text.Color.AQUA_STYLE),
                 500,
                 true
         ));

--- a/src/test/java/dev/galacticraft/mod/gametest/JUnit5XMLTestCompletionListener.java
+++ b/src/test/java/dev/galacticraft/mod/gametest/JUnit5XMLTestCompletionListener.java
@@ -23,6 +23,7 @@
 package dev.galacticraft.mod.gametest;
 
 import com.google.common.base.Stopwatch;
+import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.Galacticraft;
 import net.minecraft.gametest.framework.GameTestInfo;
 import net.minecraft.gametest.framework.TestReporter;
@@ -65,7 +66,7 @@ public class JUnit5XMLTestCompletionListener implements TestReporter {
     @Override
     public void onTestFailed(GameTestInfo test) {
         if (test.getError() != null) {
-            Galacticraft.LOGGER.error("Test " + test.getTestName() + " failed!", test.getError());
+            Constant.LOGGER.error("Test " + test.getTestName() + " failed!", test.getError());
         }
         Element failedStateElement;
         if(test.isRequired()) {


### PR DESCRIPTION
I split apart the stages of registering in GCFluids so that fluidVariantAttributes can inherit the names when calling `GCBlocks.<block>.getDescriptionId()` while not requiring the GCFluids to be registered after GCBlocks.