### PR TITLE
fix: CelestialScreen does not close when pressing esc

### DIFF
--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CelestialSelectionScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/CelestialSelectionScreen.java
@@ -332,6 +332,8 @@ public class CelestialSelectionScreen extends Screen {
         if (key == GLFW.GLFW_KEY_ESCAPE) {
             if (this.selectedBody != null) {
                 this.unselectCelestialBody();
+            } else if (this.shouldCloseOnEsc()) {
+                this.onClose();
             }
 
             return true;

--- a/src/main/java/dev/galacticraft/mod/command/GCCommands.java
+++ b/src/main/java/dev/galacticraft/mod/command/GCCommands.java
@@ -86,7 +86,7 @@ public class GCCommands {
                                             .executes(context -> openCelestialScreenWithPlayer(context, BoolArgumentType.getBool(context, "mapMode")))
                                     )
                             )
-                        .executes(context -> openCelestialScreen(context, false)));
+                        .executes(context -> openCelestialScreen(context, true)));
         });
     }
 


### PR DESCRIPTION
addresses bug #317 (also item 5 in #293)

also, I changed default behavior of /opencelestialscreen command (with no args) to put you in mapMode (this just made sense to me)