### PR TITLE
fix: ensure Cryogenic Chamber parts break when the base block is destroyed by explosion

### DIFF
--- a/src/main/java/dev/galacticraft/mod/api/block/MultiBlockMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/api/block/MultiBlockMachineBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -55,6 +56,18 @@ public abstract class MultiBlockMachineBlock extends SimpleMachineBlock implemen
         }
 
         return returnState;
+    }
+
+    @Override
+    public void wasExploded(Level world, BlockPos pos, Explosion explosion) {
+        for (BlockPos part : this.getOtherParts(world.getBlockState(pos))) {
+            part = pos.immutable().offset(part);
+            if (!(world.getBlockEntity(part) instanceof MultiBlockPart)) {
+                continue;
+            }
+            world.removeBlock(part, false);
+        }
+        super.wasExploded(world, pos, explosion);
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/mod/content/block/machine/SimpleMultiBlockMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/content/block/machine/SimpleMultiBlockMachineBlock.java
@@ -24,8 +24,12 @@ package dev.galacticraft.mod.content.block.machine;
 
 import dev.galacticraft.mod.api.block.MultiBlockMachineBlock;
 import dev.galacticraft.mod.api.block.MultiBlockPart;
+import dev.galacticraft.mod.content.GCBlocks;
+import dev.galacticraft.mod.content.block.special.SolarPanelPartBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -33,6 +37,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 public class SimpleMultiBlockMachineBlock extends MultiBlockMachineBlock {
     private final List<BlockPos> parts;
@@ -49,6 +54,21 @@ public class SimpleMultiBlockMachineBlock extends MultiBlockMachineBlock {
         super(properties, factory);
         this.parts = parts;
         this.partState = partBlock.defaultBlockState();
+    }
+
+    @Override
+    protected void onExplosionHit(BlockState state, Level world, BlockPos pos, Explosion explosion, BiConsumer<ItemStack, BlockPos> stackMerger) {
+        if (state.getBlock() != GCBlocks.ADVANCED_SOLAR_PANEL && state.getBlock() != GCBlocks.BASIC_SOLAR_PANEL) {
+            return;
+        }
+        for (BlockPos part : parts) {
+            BlockPos actualPartPos = pos.offset(part);
+            if (!(world.getBlockState(actualPartPos).getBlock() instanceof SolarPanelPartBlock)) {
+                return;
+            }
+            world.removeBlock(actualPartPos, false);
+        }
+        super.onExplosionHit(state, world, pos, explosion, stackMerger);
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/mod/content/block/machine/SimpleMultiBlockMachineBlock.java
+++ b/src/main/java/dev/galacticraft/mod/content/block/machine/SimpleMultiBlockMachineBlock.java
@@ -24,12 +24,8 @@ package dev.galacticraft.mod.content.block.machine;
 
 import dev.galacticraft.mod.api.block.MultiBlockMachineBlock;
 import dev.galacticraft.mod.api.block.MultiBlockPart;
-import dev.galacticraft.mod.content.GCBlocks;
-import dev.galacticraft.mod.content.block.special.SolarPanelPartBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -37,7 +33,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.List;
-import java.util.function.BiConsumer;
 
 public class SimpleMultiBlockMachineBlock extends MultiBlockMachineBlock {
     private final List<BlockPos> parts;
@@ -54,21 +49,6 @@ public class SimpleMultiBlockMachineBlock extends MultiBlockMachineBlock {
         super(properties, factory);
         this.parts = parts;
         this.partState = partBlock.defaultBlockState();
-    }
-
-    @Override
-    protected void onExplosionHit(BlockState state, Level world, BlockPos pos, Explosion explosion, BiConsumer<ItemStack, BlockPos> stackMerger) {
-        if (state.getBlock() != GCBlocks.ADVANCED_SOLAR_PANEL && state.getBlock() != GCBlocks.BASIC_SOLAR_PANEL) {
-            return;
-        }
-        for (BlockPos part : parts) {
-            BlockPos actualPartPos = pos.offset(part);
-            if (!(world.getBlockState(actualPartPos).getBlock() instanceof SolarPanelPartBlock)) {
-                return;
-            }
-            world.removeBlock(actualPartPos, false);
-        }
-        super.onExplosionHit(state, world, pos, explosion, stackMerger);
     }
 
     @Override

--- a/src/main/java/dev/galacticraft/mod/content/block/special/CryogenicChamberBlock.java
+++ b/src/main/java/dev/galacticraft/mod/content/block/special/CryogenicChamberBlock.java
@@ -38,6 +38,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
@@ -144,6 +145,18 @@ public class CryogenicChamberBlock extends BaseEntityBlock implements MultiBlock
                 level.destroyBlock(otherPart, false);
             }
         }
+    }
+
+    @Override
+    public void wasExploded(Level world, BlockPos pos, Explosion explosion) {
+        for (BlockPos part : this.getOtherParts(world.getBlockState(pos))) {
+            part = pos.immutable().offset(part);
+            if (!(world.getBlockEntity(part) instanceof MultiBlockPart)) {
+                continue;
+            }
+            world.removeBlock(part, false);
+        }
+        super.wasExploded(world, pos, explosion);
     }
 
     @Override


### PR DESCRIPTION
This fix ensures that all parts of the Cryogenic Chamber are properly removed when the base block is destroyed during explosions.