### PR TITLE
fix: made the lander explosion happen on the correct celestial body and disabled it creating fire

### DIFF
--- a/src/main/java/dev/galacticraft/mod/content/entity/orbital/lander/LanderEntity.java
+++ b/src/main/java/dev/galacticraft/mod/content/entity/orbital/lander/LanderEntity.java
@@ -240,7 +240,7 @@ public class LanderEntity extends AbstractLanderEntity implements Container, Sca
                     entity.setDeltaMovement(Vec3.ZERO);
                     entity.setPos(entity.getX(), this.getY() + 2.25, entity.getZ());
                 }
-                this.level().explode(this, this.getX(), this.getY(), this.getZ(), 12, true, Level.ExplosionInteraction.MOB);
+                this.level().explode(this, this.getX(), this.getY(), this.getZ(), 12, false, Level.ExplosionInteraction.MOB);
 
                 discard();
             }

--- a/src/main/java/dev/galacticraft/mod/content/teleporters/LanderCelestialTeleporterType.java
+++ b/src/main/java/dev/galacticraft/mod/content/teleporters/LanderCelestialTeleporterType.java
@@ -40,10 +40,10 @@ public class LanderCelestialTeleporterType<Config extends CelestialTeleporterCon
 
     @Override
     public void onEnterAtmosphere(ServerLevel level, ServerPlayer player, CelestialBody<?, ?> body, CelestialBody<?, ?> fromBody, Config config) {
+        player.teleportTo(level, player.getX(), 1100, player.getZ(), player.getYRot(), player.getXRot());
         LanderEntity lander = new LanderEntity(player);
         level.addFreshEntity(lander);
         lander.setPos(player.getX(), 1100, player.getZ());
-        player.teleportTo(level, player.getX(), 1100, player.getZ(), player.getYRot(), player.getXRot());
         player.startRiding(lander, true);
     }
 }


### PR DESCRIPTION
Fix makes it so when the lander hits too hard the explosion is on the correct celestial body and doesnt create fire