### PR TITLE
fix: fix solar panels not showing generation stats when blocked or full

### DIFF
--- a/src/main/generated/assets/galacticraft/lang/en_us.json
+++ b/src/main/generated/assets/galacticraft/lang/en_us.json
@@ -590,6 +590,7 @@
   "ui.galacticraft.machine.max_oxygen": "Maximum Oxygen: %s",
   "ui.galacticraft.machine.solar_panel.atmospheric_interference": "Atmospheric Interference: %s",
   "ui.galacticraft.machine.solar_panel.blocked": "Blocked",
+  "ui.galacticraft.machine.solar_panel.full": "Full",
   "ui.galacticraft.machine.solar_panel.day": "Day",
   "ui.galacticraft.machine.solar_panel.missing_source": "Missing Light Source",
   "ui.galacticraft.machine.solar_panel.night": "Night",

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
@@ -22,6 +22,7 @@
 
 package dev.galacticraft.mod.client.gui.screen.ingame;
 
+import dev.galacticraft.machinelib.api.machine.MachineStatus;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.content.block.entity.machine.AdvancedSolarPanelBlockEntity;
 import dev.galacticraft.mod.screen.SolarPanelMenu;
@@ -41,8 +42,12 @@ public class AdvancedSolarPanelScreen extends SolarPanelScreen<AdvancedSolarPane
 
     @Override
     public void appendEnergyTooltip(List<Component> list) {
-        if (this.menu.state.isActive()) {
+        if (this.menu.state.isActive() || this.menu.state.getStatus() == null) { // It never became null during testing, however when null it would crash games. Added as precaution.
             list.add(Component.translatable(Translations.Ui.GJT, this.menu.getCurrentEnergyGeneration()).setStyle(Constant.Text.Color.LIGHT_PURPLE_STYLE));
+        } else if (this.menu.state.getStatus().getType().equals(MachineStatus.Type.OTHER)) {
+            list.add(Component.translatable(Translations.SolarPanel.BLOCKED).setStyle(Constant.Text.Color.DARK_RED_STYLE));
+        } else if (this.menu.state.getStatus().getType().equals(MachineStatus.Type.OUTPUT_FULL)) {
+            list.add(Component.translatable(Translations.SolarPanel.FULL).setStyle(Constant.Text.Color.GREEN_STYLE));
         }
     }
 }

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BasicSolarPanelScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/BasicSolarPanelScreen.java
@@ -22,6 +22,7 @@
 
 package dev.galacticraft.mod.client.gui.screen.ingame;
 
+import dev.galacticraft.machinelib.api.machine.MachineStatus;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.content.block.entity.machine.BasicSolarPanelBlockEntity;
 import dev.galacticraft.mod.screen.SolarPanelMenu;
@@ -41,8 +42,12 @@ public class BasicSolarPanelScreen extends SolarPanelScreen<BasicSolarPanelBlock
 
     @Override
     public void appendEnergyTooltip(List<Component> list) {
-        if (this.menu.state.isActive()) {
+        if (this.menu.state.isActive() || this.menu.state.getStatus() == null) { // It never became null during testing, however when null it would crash games. Added as precaution.
             list.add(Component.translatable(Translations.Ui.GJT, this.menu.getCurrentEnergyGeneration()).setStyle(Constant.Text.Color.LIGHT_PURPLE_STYLE));
+        } else if (this.menu.state.getStatus().getType().equals(MachineStatus.Type.OTHER)) {
+            list.add(Component.translatable(Translations.SolarPanel.BLOCKED).setStyle(Constant.Text.Color.DARK_RED_STYLE));
+        } else if (this.menu.state.getStatus().getType().equals(MachineStatus.Type.OUTPUT_FULL)) {
+            list.add(Component.translatable(Translations.SolarPanel.FULL).setStyle(Constant.Text.Color.GREEN_STYLE));
         }
     }
 }

--- a/src/main/java/dev/galacticraft/mod/data/GCTranslationProvider.java
+++ b/src/main/java/dev/galacticraft/mod/data/GCTranslationProvider.java
@@ -280,6 +280,7 @@ public class GCTranslationProvider extends TranslationProvider {
 
         this.add(SolarPanel.ATMOSPHERIC_INTERFERENCE, "Atmospheric Interference: %s");
         this.add(SolarPanel.BLOCKED, "Blocked");
+        this.add(SolarPanel.FULL, "Full");
         this.add(SolarPanel.DAY, "Day");
         this.add(SolarPanel.MISSING_SOURCE, "Missing Light Source");
         this.add(SolarPanel.NIGHT, "Night");

--- a/src/main/java/dev/galacticraft/mod/util/Translations.java
+++ b/src/main/java/dev/galacticraft/mod/util/Translations.java
@@ -206,6 +206,7 @@ public interface Translations {
     interface SolarPanel {
         String ATMOSPHERIC_INTERFERENCE = "ui.galacticraft.machine.solar_panel.atmospheric_interference";
         String BLOCKED = "ui.galacticraft.machine.solar_panel.blocked";
+        String FULL = "ui.galacticraft.machine.solar_panel.full";
         String DAY = "ui.galacticraft.machine.solar_panel.day";
         String MISSING_SOURCE = "ui.galacticraft.machine.solar_panel.missing_source";
         String NIGHT = "ui.galacticraft.machine.solar_panel.night";


### PR DESCRIPTION
Fixed the solar panel screen not showing anything when hovering over the energy bar when the solar panel is blocked or it is full.