### PR TITLE
fix: stopped game from crashing when oxygen bubble distributor ran out of oxygen and collapsed

### DIFF
--- a/src/main/java/dev/galacticraft/mod/content/block/entity/machine/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/dev/galacticraft/mod/content/block/entity/machine/OxygenBubbleDistributorBlockEntity.java
@@ -205,6 +205,7 @@ public class OxygenBubbleDistributorBlockEntity extends MachineBlockEntity {
             this.prevSize = this.size;
             profiler.push("network");
             for (ServerPlayer player : world.players()) {
+                if (this.size < 0) this.size = 0;
                 ServerPlayNetworking.send(player, new BubbleSizePayload(pos, this.size));
             }
             profiler.pop();


### PR DESCRIPTION
fix: stopped game from crashing when oxygen bubble distributor ran out of oxygen and collapsed