### PR TITLE
feat: handle infinite fluid amount in formatFluidRemaining

### DIFF
--- a/src/main/java/dev/galacticraft/mod/util/TooltipUtil.java
+++ b/src/main/java/dev/galacticraft/mod/util/TooltipUtil.java
@@ -85,6 +85,10 @@ public class TooltipUtil {
 
     public static Component formatFluidRemaining(long amount, long capacity) {
         Component unit = Component.empty();
+        if (amount == Long.MAX_VALUE) {
+            return Component.translatable(Translations.Tooltip.INFINITE)
+                    .setStyle(Style.EMPTY.withColor(ColorUtil.getRainbow()));
+        }
         if (!Screen.hasShiftDown()) {
             amount = (long) ((double) amount / (double) (FluidConstants.BUCKET / 1000));
             capacity = (long) ((double) capacity / (double) (FluidConstants.BUCKET / 1000));


### PR DESCRIPTION
Replaces the long number with Infinite in the tooltip
![java_i7SUxzYu2X](https://github.com/user-attachments/assets/b91211c4-7ed0-45e4-8c71-b16cb47b97c2)
![java_n9h91H9699](https://github.com/user-attachments/assets/d02708a0-070d-4b9f-8f74-b7a309eab678)
