### PR TITLE
fixed wrenches not having fallback

### DIFF
--- a/src/main/java/dev/galacticraft/mod/content/item/StandardWrenchItem.java
+++ b/src/main/java/dev/galacticraft/mod/content/item/StandardWrenchItem.java
@@ -39,7 +39,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ChestBlock;

--- a/src/main/java/dev/galacticraft/mod/content/item/StandardWrenchItem.java
+++ b/src/main/java/dev/galacticraft/mod/content/item/StandardWrenchItem.java
@@ -76,65 +76,69 @@ public class StandardWrenchItem extends Item {
     public @NotNull InteractionResult useOn(UseOnContext context) {
         Player player = context.getPlayer();
         Level world = context.getLevel();
-        if (!world.isClientSide && player != null) {
-            BlockPos pos = context.getClickedPos();
-            this.use(player, world.getBlockState(pos), world, pos, context.getHand(), context.getItemInHand());
-        }
-        return InteractionResult.sidedSuccess(world.isClientSide);
-    }
-
-    private void use(Player player, BlockState state, LevelAccessor world, BlockPos pos, InteractionHand hand, ItemStack stack) {
+        BlockPos pos = context.getClickedPos();
+        BlockState state = world.getBlockState(pos);
         Block block = state.getBlock();
-        if (block.getStateDefinition().getProperty("facing") instanceof EnumProperty property) {
-            if (block instanceof ChestBlock && state.getValue(ChestBlock.TYPE) != ChestType.SINGLE) {
-                BlockPos otherPos = pos.relative(ChestBlock.getConnectedDirection(state));
-                BlockState otherState = world.getBlockState(otherPos);
-                Direction facing = state.getValue(ChestBlock.FACING).getOpposite();
-                world.setBlock(otherPos, state.setValue(ChestBlock.FACING, facing), 3);
-                world.setBlock(pos, otherState.setValue(ChestBlock.FACING, facing), 3);
-            } else if (block instanceof BedBlock) {
-                BlockPos otherPos = pos.relative(BedBlock.getConnectedDirection(state));
-                BlockState otherState = world.getBlockState(otherPos);
-                Direction facing = state.getValue(BedBlock.FACING).getOpposite();
-                world.setBlock(otherPos, state.setValue(BedBlock.FACING, facing), 18);
-                world.setBlock(pos, otherState.setValue(BedBlock.FACING, facing), 3);
-            } else if (block instanceof CryogenicChamberBlock || block instanceof CryogenicChamberPart) {
-                int offset = 0;
-                if (block instanceof CryogenicChamberPart) {
-                    offset = state.getValue(CryogenicChamberPart.TOP) ? -2 : -1;
-                }
-                for (int i = 0; i < 3; i++) {
-                    BlockPos partPos = pos.above(i + offset);
-                    BlockState newState = cycle(world.getBlockState(partPos), property, player.isShiftKeyDown());
-                    world.setBlock(partPos, newState, 3);
-                }
-            } else {
-                Collection<?> possibleValues = property.getPossibleValues();
-                if (possibleValues.size() <= Direction.values().length) {
-                    for (Object value : possibleValues) {
-                        if (!(value instanceof Direction)) {
-                            return;
-                        }
-                    }
 
-                    Collection<Direction> sortedValues = ((Collection<Direction>) possibleValues).stream()
-                            .sorted(Comparator.comparingInt(direction -> direction.get2DDataValue()))
-                            .filter(direction -> state.setValue(property, direction).canSurvive(world, pos))
-                            .collect(Collectors.toList());
-                    BlockState newState = cycle(state, property, sortedValues, player.isShiftKeyDown());
-                    world.setBlock(pos, newState, 3);
+        if (!world.isClientSide && player != null) {
+            boolean handled = false;
+
+            if (block.getStateDefinition().getProperty("facing") instanceof EnumProperty property) {
+                if (block instanceof ChestBlock && state.getValue(ChestBlock.TYPE) != ChestType.SINGLE) {
+                    BlockPos otherPos = pos.relative(ChestBlock.getConnectedDirection(state));
+                    BlockState otherState = world.getBlockState(otherPos);
+                    Direction facing = state.getValue(ChestBlock.FACING).getOpposite();
+                    world.setBlock(otherPos, state.setValue(ChestBlock.FACING, facing), 3);
+                    world.setBlock(pos, otherState.setValue(ChestBlock.FACING, facing), 3);
+                    handled = true;
+                } else if (block instanceof BedBlock) {
+                    BlockPos otherPos = pos.relative(BedBlock.getConnectedDirection(state));
+                    BlockState otherState = world.getBlockState(otherPos);
+                    Direction facing = state.getValue(BedBlock.FACING).getOpposite();
+                    world.setBlock(otherPos, state.setValue(BedBlock.FACING, facing), 18);
+                    world.setBlock(pos, otherState.setValue(BedBlock.FACING, facing), 3);
+                    handled = true;
+                } else if (block instanceof CryogenicChamberBlock || block instanceof CryogenicChamberPart) {
+                    int offset = (block instanceof CryogenicChamberPart && state.getValue(CryogenicChamberPart.TOP)) ? -2 :
+                            (block instanceof CryogenicChamberPart) ? -1 : 0;
+                    for (int i = 0; i < 3; i++) {
+                        BlockPos partPos = pos.above(i + offset);
+                        BlockState newState = cycle(world.getBlockState(partPos), property, player.isShiftKeyDown());
+                        world.setBlock(partPos, newState, 3);
+                    }
+                    handled = true;
+                } else {
+                    Collection<?> possibleValues = property.getPossibleValues();
+                    if (possibleValues.stream().allMatch(Direction.class::isInstance)) {
+                        Collection<Direction> sortedValues = ((Collection<Direction>) possibleValues).stream()
+                                .sorted(Comparator.comparingInt(Direction::get2DDataValue))
+                                .filter(dir -> state.setValue(property, dir).canSurvive(world, pos))
+                                .collect(Collectors.toList());
+
+                        BlockState newState = cycle(state, property, sortedValues, player.isShiftKeyDown());
+                        world.setBlock(pos, newState, 3);
+                        handled = true;
+                    }
                 }
+            } else if (block.getStateDefinition().getProperty("axis") instanceof EnumProperty property) {
+                BlockState newState = cycle(state, property, player.isShiftKeyDown());
+                world.setBlock(pos, newState, 3);
+                handled = true;
+            } else if (block.getStateDefinition().getProperty("rotation") instanceof IntegerProperty property) {
+                BlockState newState = cycle(state, property, player.isShiftKeyDown());
+                world.setBlock(pos, newState, 3);
+                handled = true;
             }
-            stack.hurtAndBreak(1, player, hand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-        } else if (block.getStateDefinition().getProperty("axis") instanceof EnumProperty property) {
-            BlockState newState = cycle(state, property, player.isShiftKeyDown());
-            world.setBlock(pos, newState, 3);
-            stack.hurtAndBreak(1, player, hand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
-        } else if (block.getStateDefinition().getProperty("rotation") instanceof IntegerProperty property) {
-            BlockState newState = cycle(state, property, player.isShiftKeyDown());
-            world.setBlock(pos, newState, 3);
-            stack.hurtAndBreak(1, player, hand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
+
+            if (handled) {
+                context.getItemInHand().hurtAndBreak(1, player,
+                        context.getHand() == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND);
+                return InteractionResult.SUCCESS;
+            }
         }
+
+        // Fallback
+        return super.useOn(context);
     }
 
     @Override


### PR DESCRIPTION
Small fix adding fallback to wrenches. Wrenches now fall back to normal item usage if they are used on a block that doesnt have custom behaviour/rotation