### PR TITLE
feat: pre-commit and pre-push git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,17 @@ then
 	echo -e "...spotlessCheck succeeded, proceeding with git commit.\n"
 else
 	echo -e "...spotlessCheck failed, aborting git commit.\n"
-	echo -e "Run './gradlew spotlessApply' to fix these violations.\n"
+	echo -e "Started running './gradlew spotlessApply' to fix these violations..."
+
+	./gradlew spotlessApply &>/dev/null
+	applied=$?
+
+	if test "$applied" = 0
+	then
+		echo "...spotlessApply succeeded, stage these changes and re-commit."
+	else
+		echo "...spotlessApply failed."
+	fi
 fi
 
 exit $status

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,9 +7,9 @@ status=$?
 
 if test "$status" = 0
 then
-	echo -e "...spotlessCheck succeeded, proceeding with git push.\n"
+	echo -e "...spotlessCheck succeeded, proceeding with git commit.\n"
 else
-	echo -e "...spotlessCheck failed, aborting git push.\n"
+	echo -e "...spotlessCheck failed, aborting git commit.\n"
 	echo -e "Run './gradlew spotlessApply' to fix these violations.\n"
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,7 +2,8 @@
 
 echo -e "Started running './gradlew test' Gradle task...\n"
 
-./gradlew test &>/dev/null
+./gradlew test
+
 status=$?
 
 if test "$status" = 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,8 +2,7 @@
 
 echo -e "Started running './gradlew test' Gradle task...\n"
 
-./gradlew test
-
+./gradlew :test
 status=$?
 
 if test "$status" = 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,16 +1,15 @@
 #!/bin/sh
 
-echo "Started running './gradlew spotlessCheck' Gradle task..."
+echo -e "Started running './gradlew test' Gradle task...\n"
 
-./gradlew spotlessCheck &>/dev/null
+./gradlew test &>/dev/null
 status=$?
 
 if test "$status" = 0
 then
-	echo -e "...spotlessCheck succeeded, proceeding with git push.\n"
+	echo -e "...test succeeded, proceeding with git push.\n"
 else
-	echo -e "...spotlessCheck failed, aborting git push.\n"
-	echo -e "Run './gradlew spotlessApply' to fix these violations.\n"
+	echo -e "...test failed, aborting git push.\n"
 fi
 
 exit $status

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Started running './gradlew spotlessCheck' gradle task..."
+
+./gradlew spotlessCheck &>/dev/null
+status=$?
+
+if test "$status" = 0
+then
+	echo -e "...spotlessCheck succeeded, proceeding with git push.\n"
+else
+	echo -e "...spotlessCheck failed, aborting git push.\n"
+	echo -e "Run './gradlew spotlessApply' to fix these violations.\n"
+fi
+
+exit $status

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-echo -e "Started running './gradlew test' Gradle task...\n"
+echo -e "Started running './gradlew test' Gradle task..."
 
 ./gradlew :test
 status=$?
 
 if test "$status" = 0
 then
-	echo -e "...test succeeded, proceeding with git push.\n"
+	echo -e "\n...test succeeded, proceeding with git push.\n"
 else
-	echo -e "...test failed, aborting git push.\n"
+	echo -e "\n...test failed, aborting git push.\n"
 fi
 
 exit $status

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ In order to enable the Git Hooks in this repository, use the following command:
 git config --local core.hooksPath .githooks/
 ```
 
-The pre-push Git Hook runs the spotlessCheck Gradle task before each Git Push and aborts pushing if the check fails. This is useful to avoid a lot of commits to fix spotless violations.
+The pre-commit Git Hook runs the spotlessCheck Gradle task before each git commit and aborts committing if the check fails. The pre-push Git Hook runs the spotlessCheck Gradle task before each git push and aborts pushing if the check fails. These are useful to avoid a lot of commits to fix spotless violations.
 
 #### Commit Message
 We use [conventional commits][conventional commits] specification to write commit messages.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,18 +79,20 @@ If any files are missing the header, you can add it by executing the following G
 ./gradlew updateLicenses
 ```
 
-The following Gradle task adds missing license headers, as well as removing unused imports and replacing tabs with spaces:
+Alternatively, as well as adding missing license headers, the following Gradle task also removes unused imports and replaces tabs with spaces:
 ```shell
 ./gradlew spotlessApply
 ```
 
 #### Git Hooks
-In order to enable the Git Hooks in this repository, use the following command:
+In order to enable the Git Hooks in this repository, which are useful to avoid lots commits to fix spotless violations, use the following command:
 ```shell
 git config --local core.hooksPath .githooks/
 ```
 
-The pre-commit Git Hook runs the `spotlessCheck` Gradle task before each git commit and aborts committing if the check fails, after running the `spotlessApply` Gradle task. The pre-push Git Hook runs the `test` Gradle task before each git push and aborts pushing if the test fails. These are useful to avoid a lot of commits to fix spotless violations.
+The pre-commit Git Hook runs the `spotlessCheck` Gradle task before each git commit and aborts committing if the check fails, after running the `spotlessApply` Gradle task.
+
+The pre-push Git Hook runs the `test` Gradle task before each git push and aborts pushing if the test fails.
 
 #### Commit Message
 We use [conventional commits][conventional commits] specification to write commit messages.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,6 +79,19 @@ If any files are missing the header, you can add it by executing the following G
 ./gradlew updateLicenses
 ```
 
+The following Gradle task adds missing license headers, as well as removing unused imports and replacing tabs with spaces:
+```shell
+./gradlew spotlessApply
+```
+
+#### Git Hooks
+In order to enable the Git Hooks in this repository, use the following command:
+```shell
+git config --local core.hooksPath .githooks/
+```
+
+The pre-push Git Hook runs the spotlessCheck Gradle task before each Git Push and aborts pushing if the check fails. This is useful to avoid a lot of commits to fix spotless violations.
+
 #### Commit Message
 We use [conventional commits][conventional commits] specification to write commit messages.
 However, we tend to squash-merge pull requests, so you are not required to do this.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ They can be found on the [GitHub Actions][actions] tab (select a commit and look
 * Please create a separate bug report for each bug that you find.
   * This makes it easier to keep track of what is and is not fixed.
 * Please include either the commit hash (e.g., `a17fe4784ed658a9c70ecebd2173af755299d0cb`)
-or the GitHub actions build number (e.g., #253) in your report.
+or the GitHub Actions build number (e.g., #253) in your report.
   * Commit hashes are preferred, but the build number is acceptable too.
   * This helps us figure out when a bug may have been introduced,
   or if there are any commit(s) that may have already fixed this bug. 
@@ -54,11 +54,11 @@ Feel free to use `var` for variables with obvious types.
 > Do not manually edit or add any files to [`src/main/generated`][generated] as they will be deleted.
 
 #### Textures, Music and Complex Models
-These (and other non-generatable) resources belong in the [`src/main/resources`] directory.
+These (and other non-generatable) resources belong in the [`src/main/resources`][resources] directory.
 
 #### Simple Models, Loot Tables, and Tags
 These (and other generatable) resources are programmatically created using Minecraft's datagen system.
-See the [`dev.galacticraft.mod.data`](/src/main/java/dev/galacticraft/mod/data) package to see how these are generated.
+See the [`dev.galacticraft.mod.data`][datagen] package to see how these are generated.
 
 ### Before Committing Changes
 
@@ -94,7 +94,7 @@ The pre-commit Git Hook runs the `spotlessCheck` Gradle task before each git com
 
 The pre-push Git Hook runs the `test` Gradle task before each git push and aborts pushing if the test fails.
 
-#### Commit Message
+#### Commit Messages
 We use [conventional commits][conventional commits] specification to write commit messages.
 However, we tend to squash-merge pull requests, so you are not required to do this.
 
@@ -102,6 +102,8 @@ However, we tend to squash-merge pull requests, so you are not required to do th
 [actions]: https://github.com/TeamGalacticraft/Galacticraft/actions/workflows/build.yml?query=branch%3Amain+is%3Asuccess
 [conventional commits]: https://www.conventionalcommits.org
 [crowdin]: https://teamgalacticraft.crowdin.com/galacticraft
+[datagen]: /src/main/java/dev/galacticraft/mod/data
 [discord]: https://discord.gg/n3QqhMYyFK
 [generated]: /src/main/generated
 [license header]: /LICENSE_HEADER.txt
+[resources]: /src/main/resources

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ In order to enable the Git Hooks in this repository, use the following command:
 git config --local core.hooksPath .githooks/
 ```
 
-The pre-commit Git Hook runs the spotlessCheck Gradle task before each git commit and aborts committing if the check fails. The pre-push Git Hook runs the spotlessCheck Gradle task before each git push and aborts pushing if the check fails. These are useful to avoid a lot of commits to fix spotless violations.
+The pre-commit Git Hook runs the `spotlessCheck` Gradle task before each git commit and aborts committing if the check fails, after running the `spotlessApply` Gradle task. The pre-push Git Hook runs the `test` Gradle task before each git push and aborts pushing if the test fails. These are useful to avoid a lot of commits to fix spotless violations.
 
 #### Commit Message
 We use [conventional commits][conventional commits] specification to write commit messages.


### PR DESCRIPTION
In order to enable the Git Hooks in this repository, which are useful to avoid lots commits to fix spotless violations, use the following command:
```shell
git config --local core.hooksPath .githooks/
```

The pre-commit Git Hook runs the `spotlessCheck` Gradle task before each git commit and aborts committing if the check fails, after running the `spotlessApply` Gradle task.

The pre-push Git Hook runs the `test` Gradle task before each git push and aborts pushing if the test fails.