### PR TITLE
feat: implement the getCloneItemStack method for CannedFoodBlock

### DIFF
--- a/src/main/java/dev/galacticraft/mod/client/model/CannedFoodBakedModel.java
+++ b/src/main/java/dev/galacticraft/mod/client/model/CannedFoodBakedModel.java
@@ -44,6 +44,7 @@ public class CannedFoodBakedModel extends ForwardingBakedModel {
 
     // Define relative positions for each can layout
     public static float[][][] POSITIONS = {
+            {}, // 0 cans
             {{8, 0, 8}}, // 1 can
             {{4, 0, 8}, {12, 0, 8}}, // 2 cans
             {{4, 0, 4}, {12, 0, 6}, {6, 0, 12}}, // 3 cans
@@ -60,7 +61,7 @@ public class CannedFoodBakedModel extends ForwardingBakedModel {
         int canCount = contents.size();
 
         for (int i = 0; i < canCount; i++) {
-            float[] position = POSITIONS[canCount - 1][i];
+            float[] position = POSITIONS[canCount][i];
             float x0 = (position[0] - 8) / 16.0f; // Convert pixel coords to block space
             float y = position[1] / 16.0f;
             float z0 = (position[2] - 8) / 16.0f;

--- a/src/main/java/dev/galacticraft/mod/content/block/decoration/CannedFoodBlock.java
+++ b/src/main/java/dev/galacticraft/mod/content/block/decoration/CannedFoodBlock.java
@@ -24,11 +24,15 @@ package dev.galacticraft.mod.content.block.decoration;
 
 import dev.galacticraft.mod.client.model.CannedFoodBakedModel;
 import dev.galacticraft.mod.content.block.entity.decoration.CannedFoodBlockEntity;
+import dev.galacticraft.mod.content.item.CannedFoodItem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -36,12 +40,19 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static dev.galacticraft.mod.content.item.GCItems.EMPTY_CAN;
 
 public class CannedFoodBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
@@ -71,13 +82,12 @@ public class CannedFoodBlock extends Block implements EntityBlock {
     @Override
     public @NotNull VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
         VoxelShape shape = Shapes.empty();
-        BlockEntity be = world.getBlockEntity(pos);
-        if (be instanceof CannedFoodBlockEntity cannedFoodBlockEntity) {
+        if (world.getBlockEntity(pos) instanceof CannedFoodBlockEntity cannedFoodBlockEntity) {
             Direction direction = state.getValue(FACING);
             float a = direction.getStepX();
             float b = direction.getStepZ();
 
-            for (float[] position : CannedFoodBakedModel.POSITIONS[cannedFoodBlockEntity.getCanCount() - 1]) {
+            for (float[] position : CannedFoodBakedModel.POSITIONS[cannedFoodBlockEntity.getCanCount()]) {
                 float x = a * (position[2] - 8) + b * (position[0] - 8);
                 float y = position[1];
                 float z = b * (position[2] - 8) - a * (position[0] - 8);
@@ -91,11 +101,47 @@ public class CannedFoodBlock extends Block implements EntityBlock {
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean moved) {
         if (!state.is(newState.getBlock())) {
-            BlockEntity be = level.getBlockEntity(pos);
-            if (be instanceof CannedFoodBlockEntity blockEntity) {
+            if (level.getBlockEntity(pos) instanceof CannedFoodBlockEntity blockEntity) {
                 blockEntity.dropStoredCans(level, pos);
             }
             super.onRemove(state, level, pos, newState, moved);
         }
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader levelReader, BlockPos pos, BlockState state) {
+        if (levelReader.isClientSide() && levelReader.getBlockEntity(pos) instanceof CannedFoodBlockEntity blockEntity) {
+            HitResult hitResult = Minecraft.getInstance().hitResult;
+            if (hitResult != null) {
+                Vec3 location = hitResult.getLocation();
+                double minDist = 1.0D;
+
+                Direction direction = state.getValue(FACING);
+                float a = direction.getStepX();
+                float b = direction.getStepZ();
+
+                ItemStack itemStack = ItemStack.EMPTY;
+                List<ItemStack> canContents = blockEntity.getCanContents();
+                int canCount = canContents.size();
+                for (int i = 0; i < canCount; i++) {
+                    float[] position = CannedFoodBakedModel.POSITIONS[canCount][i];
+                    double x = pos.getX() + (a * (position[2] - 8) + b * (position[0] - 8) + 5) / 16.0D;
+                    double y = pos.getY() + position[1] / 16.0D;
+                    double z = pos.getZ() + (b * (position[2] - 8) - a * (position[0] - 8) + 5) / 16.0D;
+
+                    AABB shape = new AABB(x, y, z, x + 0.375D, y + 0.5D, z + 0.375D);
+                    double dist = shape.distanceToSqr(location);
+                    if (dist < minDist) {
+                        minDist = dist;
+                        itemStack = canContents.get(i);
+                    }
+                }
+
+                if (CannedFoodItem.getSize(itemStack) > 0) {
+                    return itemStack;
+                }
+            }
+        }
+        return EMPTY_CAN.getDefaultInstance();
     }
 }


### PR DESCRIPTION
Allow pick block (middle click) to be used to quickly get an individual canned food item from a stack of cans.

https://github.com/user-attachments/assets/08a6129c-6ba4-4b0a-9ce2-35a6bf3e7efd