### PR TITLE
feat: automatically set required Minecraft and Fabric API versions in fabric.mod.json

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -271,6 +271,7 @@ tasks.processResources {
     val properties = mapOf(
         "version" to project.version,
         "fabricVersion" to project.property("fabric.version"),
+        "minecraftVersion" to project.property("minecraft.version"),
     )
     inputs.properties(properties)
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -326,7 +326,7 @@
     }
   },
   "depends": {
-    "minecraft": ">=1.21",
+    "minecraft": "=$minecraftVersion",
     "fabricloader": ">=0.15.3",
     "fabric-api": ">=$fabricVersion"
   },


### PR DESCRIPTION
The game now shows an error message when trying to run Galacticraft without Fabric API installed or with the wrong Minecraft version:
<img width="1063" height="586" alt="image" src="https://github.com/user-attachments/assets/a1da7c47-fd99-42e0-ad1a-00566b1e0be2" />
