### PR TITLE
fix: drop items from the slots in the creative Galacticraft gear inventory without crashing

### DIFF
--- a/src/main/java/dev/galacticraft/mod/client/gui/widget/RadioButton.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/widget/RadioButton.java
@@ -23,6 +23,7 @@
 package dev.galacticraft.mod.client.gui.widget;
 
 import dev.galacticraft.mod.Constant;
+import dev.galacticraft.mod.util.DrawableUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
@@ -74,13 +75,9 @@ public class RadioButton extends AbstractWidget {
     }
 
     public int getButtonHovered(int mouseX, int mouseY) {
-        if (mouseX >= getX() && mouseX < getX() + BTN_WIDTH &&
-                mouseY >= getY() && mouseY < getY() + BTN_HEIGHT) {
+        if (DrawableUtil.mouseIn(mouseX, mouseY, getX(), getY(), BTN_WIDTH, BTN_HEIGHT)) {
             return 0;
-        }
-
-        if (mouseX >= getX() && mouseX < getX() + BTN_WIDTH &&
-                mouseY >= getY() + BTN_HEIGHT && mouseY < getY() + BTN_HEIGHT * 2) {
+        } else if (DrawableUtil.mouseIn(mouseX, mouseY, getX(), getY() + BTN_HEIGHT, BTN_WIDTH, BTN_HEIGHT)) {
             return 1;
         }
         return -1;

--- a/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
@@ -139,33 +139,27 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
     private void onMouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
-
-        //Item duplication support
-        if (button == 2) {
+        if (isGCInventoryEnabled() && selectedTab.getType() == CreativeModeTab.Type.INVENTORY) {
             Slot slot = gc$findSlot(mouseX, mouseY);
             if (slot != null) {
-                getMenu().setCarried(slot.getItem().copy());
-            }
-            return;
-        }
-
-        if (selectedTab.getType() == CreativeModeTab.Type.INVENTORY) {
-            if (isGCInventoryEnabled()) {
                 ItemStack carried = getMenu().getCarried();
-                Slot slot = gc$findSlot(mouseX, mouseY);
-                if (slot != null) {
-                    //Quick stack
-                    if (Screen.hasShiftDown()) {
-                        gcTryQuickStackToPlayerInv(slot);
-                    } else if (carried.isEmpty() || slot.mayPlace(carried)) {
-                        getMenu().setCarried(slot.getItem());
-                        slot.set(carried);
-                        slot.setChanged();
-                        ClientPlayNetworking.send(new CreativeGcTransferItemPayload(1, slot.getContainerSlot(), carried.isEmpty() ? 0 : 1, carried));
+
+                if (this.minecraft.options.keyPickItem.matchesMouse(button) && this.minecraft.gameMode.hasInfiniteItems()) {
+                    // Item duplication support
+                    if (carried.isEmpty()) {
+                        ItemStack itemStack = slot.getItem();
+                        getMenu().setCarried(itemStack.copyWithCount(itemStack.getMaxStackSize()));
                     }
-                    cir.setReturnValue(true);
-                    return;
+                } else if (Screen.hasShiftDown()) {
+                    gcTryQuickStackToPlayerInv(slot);
+                } else if (carried.isEmpty() || slot.mayPlace(carried)) {
+                    getMenu().setCarried(slot.getItem());
+                    slot.set(carried);
+                    slot.setChanged();
+                    ClientPlayNetworking.send(new CreativeGcTransferItemPayload(1, slot.getContainerSlot(), carried.isEmpty() ? 0 : 1, carried));
                 }
+
+                cir.setReturnValue(true);
             }
         }
     }
@@ -206,7 +200,7 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
     @Unique
     private Slot gc$findSlot(double x, double y) {
         for (int i = 0; i < gc$slots.size(); ++i) {
-            Slot slot = (Slot) gc$slots.get(i);
+            Slot slot = gc$slots.get(i);
             if (isHovering(slot.x, slot.y, 16, 16, x, y) && slot.isActive()) {
                 return slot;
             }

--- a/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
@@ -68,7 +68,7 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
 
     @Shadow @Nullable private Slot destroyItemSlot;
     @Shadow @Final private static SimpleContainer CONTAINER;
-    @Unique private final List<AccessorySlot> gc$slots = new ArrayList<>();
+    @Unique private final List<CreativeModeInventoryScreen.SlotWrapper> gc$slots = new ArrayList<>();
 
     @Unique private RadioButton creativeSwitchButton;
 
@@ -171,7 +171,7 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
                 if (gcTryQuickStackToGCInv(slot)) {
                     ci.cancel();
                 }
-            } else if (slot != null && slot instanceof AccessorySlot) {
+            } else if (slot != null && slot.container == this.minecraft.player.galacticraft$getGearInv()) {
                 if (clickType == ClickType.THROW && slot.hasItem()) {
                     ItemStack dropped = slot.remove(button == 0 ? 1 : slot.getItem().getMaxStackSize());
                     ItemStack remaining = slot.getItem();
@@ -227,14 +227,19 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
 
     @Unique
     private void generateGCSlot(int x, int y, int idx) {
-        gc$slots.add(new AccessorySlot(
-                minecraft.player.galacticraft$getGearInv(),
-                minecraft.player,
+        gc$slots.add(new CreativeModeInventoryScreen.SlotWrapper(
+                new AccessorySlot(
+                        minecraft.player.galacticraft$getGearInv(),
+                        minecraft.player,
+                        idx,
+                        x,
+                        y,
+                        GCAccessorySlots.SLOT_TAGS.get(idx),
+                        GCAccessorySlots.SLOT_SPRITES.get(idx)
+                ),
                 idx,
                 x,
-                y,
-                GCAccessorySlots.SLOT_TAGS.get(idx),
-                GCAccessorySlots.SLOT_SPRITES.get(idx)
+                y
         ));
     }
 

--- a/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
+++ b/src/main/java/dev/galacticraft/mod/mixin/client/CreativeScreenMixin.java
@@ -170,6 +170,26 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
         }
     }
 
+    @Inject(method = "slotClicked", at = @At("HEAD"), cancellable = true)
+    private void onSlotClicked(Slot slot, int slotId, int button, ClickType clickType, CallbackInfo ci) {
+        if (isGCInventoryEnabled() && selectedTab.getType() == CreativeModeTab.Type.INVENTORY) {
+            if (clickType == ClickType.QUICK_MOVE) {
+                if (gcTryQuickStackToGCInv(slot)) {
+                    ci.cancel();
+                }
+            } else if (slot != null && slot instanceof AccessorySlot) {
+                if (clickType == ClickType.THROW && slot.hasItem()) {
+                    ItemStack dropped = slot.remove(button == 0 ? 1 : slot.getItem().getMaxStackSize());
+                    ItemStack remaining = slot.getItem();
+                    this.minecraft.player.drop(dropped, true);
+                    this.minecraft.gameMode.handleCreativeModeItemDrop(dropped);
+                    ClientPlayNetworking.send(new CreativeGcTransferItemPayload(1, slot.getContainerSlot(), remaining.isEmpty() ? 0 : 1, remaining));
+                    ci.cancel();
+                }
+            }
+        }
+    }
+
     @Unique
     private void regenerateSlots() {
         gc$slots.clear();
@@ -262,13 +282,6 @@ public abstract class CreativeScreenMixin extends EffectRenderingInventoryScreen
                 minecraft.player.inventoryMenu.broadcastChanges();
                 return;
             }
-        }
-    }
-
-    @Inject(method = "slotClicked", at = @At("HEAD"))
-    protected void slotClicked(Slot region, int slotId, int button, ClickType actionType, CallbackInfo ci) {
-        if (region != null && actionType == ClickType.QUICK_MOVE) {
-            gcTryQuickStackToGCInv(region);
         }
     }
 


### PR DESCRIPTION
Fixes #559

Added a few extra checks to only target our own slots, so it should be safer in general.

Also makes the item duplication support more consistent with the vanilla behaviour.