### PR TITLE
fix: Increase the animation speed of the Space Race Screen opening, so it's not painfully slow

### DIFF
--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class SpaceRaceScreen extends Screen {
+    private long openingStartTime = -1;
     private int backgroundWidth = 0;
     private int backgroundHeight = 0;
     private Menu menu = Menu.MAIN;
@@ -138,6 +139,9 @@ public class SpaceRaceScreen extends Screen {
     @Override
     protected void init() {
         super.init();
+        if (this.openingStartTime == -1) {
+            this.openingStartTime = System.currentTimeMillis();
+        }
         createMenu(this.menu);
     }
 
@@ -162,23 +166,30 @@ public class SpaceRaceScreen extends Screen {
 
     @Override
     public void renderBackground(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        // 5% of width
+        long elapsed = System.currentTimeMillis() - this.openingStartTime;
+        long duration = 1000; // This is how long (ms) it will take to open the GUI
+        float progress = Math.min(1.0f, (float) elapsed / duration);
+
+        float smoothedProgress = 1.0f - (float) Math.pow(1.0f - progress, 3);
+
         int maxWidth = (int) (this.width - (getXMargins() * 1.5D));
-        if (backgroundWidth < maxWidth) {
-            backgroundWidth += (int) Math.min(120 * delta, maxWidth - backgroundWidth);
-        }
-
         int maxHeight = (int) (this.height - (getYMargins() * 1.5D));
-        if (backgroundHeight < maxHeight) {
-            backgroundHeight += (int) Math.min(80 * delta, maxHeight - backgroundHeight);
-        }
 
-        if (!this.animationCompleted && this.isAnimationComplete()) {
+        this.backgroundWidth = (int) (maxWidth * smoothedProgress);
+        this.backgroundHeight = (int) (maxHeight * smoothedProgress);
+
+        if (!this.animationCompleted && progress >= 1.0f) {
             this.repositionElements();
             this.animationCompleted = true;
         }
 
         graphics.fill(getLeft(), getTop(), getLeft() + backgroundWidth, getTop() + backgroundHeight, 0x80000000);
+    }
+
+    @Override
+    public void onClose() {
+        this.openingStartTime = -1;
+        super.onClose();
     }
 
     private void renderForeground(GuiGraphics graphics, int mouseX, int mouseY) {
@@ -235,13 +246,6 @@ public class SpaceRaceScreen extends Screen {
             case TEAM_FLAG -> teamFlagMenu();
             case TEAM_COLOR -> teamColorMenu();
         }
-    }
-
-    private boolean isAnimationComplete() {
-        int maxWidth = (int) (this.width - (getXMargins() * 1.5D));
-        int maxHeight = (int) (this.height - (getYMargins() * 1.5D));
-
-        return backgroundWidth >= maxWidth && backgroundHeight >= maxHeight;
     }
 
     private int getYMargins() {

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
@@ -165,12 +165,12 @@ public class SpaceRaceScreen extends Screen {
         // 5% of width
         int maxWidth = (int) (this.width - (getXMargins() * 1.5D));
         if (backgroundWidth < maxWidth) {
-            backgroundWidth += (int) Math.min(60 * delta, maxWidth - backgroundWidth);
+            backgroundWidth += (int) Math.min(120 * delta, maxWidth - backgroundWidth);
         }
 
         int maxHeight = (int) (this.height - (getYMargins() * 1.5D));
         if (backgroundHeight < maxHeight) {
-            backgroundHeight += (int) Math.min(40 * delta, maxHeight - backgroundHeight);
+            backgroundHeight += (int) Math.min(80 * delta, maxHeight - backgroundHeight);
         }
 
         if (!this.animationCompleted && this.isAnimationComplete()) {

--- a/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
+++ b/src/main/java/dev/galacticraft/mod/client/gui/screen/ingame/SpaceRaceScreen.java
@@ -146,6 +146,12 @@ public class SpaceRaceScreen extends Screen {
     }
 
     @Override
+    public void onClose() {
+        this.openingStartTime = -1;
+        super.onClose();
+    }
+
+    @Override
     public void resize(Minecraft client, int width, int height) {
         this.backgroundWidth = (int) (width - ((this.getMarginPercent() * width) * 1.5D));
         this.backgroundHeight = (int) (height - ((this.getMarginPercent() * height) * 1.5D));
@@ -166,30 +172,26 @@ public class SpaceRaceScreen extends Screen {
 
     @Override
     public void renderBackground(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-        long elapsed = System.currentTimeMillis() - this.openingStartTime;
-        long duration = 1000; // This is how long (ms) it will take to open the GUI
-        float progress = Math.min(1.0f, (float) elapsed / duration);
+        if (!this.animationCompleted) {
+            int maxWidth = (int) (this.width - (getXMargins() * 1.5D));
+            int maxHeight = (int) (this.height - (getYMargins() * 1.5D));
 
-        float smoothedProgress = 1.0f - (float) Math.pow(1.0f - progress, 3);
+            if (this.backgroundWidth >= maxWidth && this.backgroundHeight >= maxHeight) {
+                this.repositionElements();
+                this.animationCompleted = true;
+            }
 
-        int maxWidth = (int) (this.width - (getXMargins() * 1.5D));
-        int maxHeight = (int) (this.height - (getYMargins() * 1.5D));
+            long elapsed = System.currentTimeMillis() - this.openingStartTime;
+            long duration = 1000; // This is how long (ms) it will take to open the GUI
+            float progress = Math.min(1.0f, (float) elapsed / duration);
 
-        this.backgroundWidth = (int) (maxWidth * smoothedProgress);
-        this.backgroundHeight = (int) (maxHeight * smoothedProgress);
+            float smoothedProgress = 1.01f - (float) Math.pow(1.0f - progress, 3);
 
-        if (!this.animationCompleted && progress >= 1.0f) {
-            this.repositionElements();
-            this.animationCompleted = true;
+            this.backgroundWidth = (int) (maxWidth * smoothedProgress);
+            this.backgroundHeight = (int) (maxHeight * smoothedProgress);
         }
 
-        graphics.fill(getLeft(), getTop(), getLeft() + backgroundWidth, getTop() + backgroundHeight, 0x80000000);
-    }
-
-    @Override
-    public void onClose() {
-        this.openingStartTime = -1;
-        super.onClose();
+        graphics.fill(getLeft(), getTop(), getRight(), getBottom(), 0x80000000);
     }
 
     private void renderForeground(GuiGraphics graphics, int mouseX, int mouseY) {


### PR DESCRIPTION
Increased the Space Race Screen animation values from 60 and 40 to 120 and 80. Previously it'd take ridiculously long to open, not sure if it was just me a thing

Before:
https://github.com/user-attachments/assets/653d68af-7d73-4eb0-9f4a-657eea135f5f

After:
https://github.com/user-attachments/assets/90def299-8900-41aa-8791-8ea49fb7020e

