### PR TITLE
Fix glitching items when dimensions change

### DIFF
--- a/src/main/java/dev/galacticraft/impl/internal/fabric/GalacticraftAPI.java
+++ b/src/main/java/dev/galacticraft/impl/internal/fabric/GalacticraftAPI.java
@@ -36,18 +36,23 @@ import dev.galacticraft.dynamicdimensions.api.event.DynamicDimensionLoadCallback
 import dev.galacticraft.impl.internal.command.GCApiCommands;
 import dev.galacticraft.impl.network.GCApiPackets;
 import dev.galacticraft.impl.network.GCApiServerPacketReceivers;
+import dev.galacticraft.impl.network.s2c.GearInvPayload;
 import dev.galacticraft.impl.universe.BuiltinObjects;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.data.gen.SatelliteChunkGenerator;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistrySetupCallback;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.LevelResource;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -85,6 +90,16 @@ public class GalacticraftAPI implements ModInitializer {
         DynamicDimensionLoadCallback.register((minecraftServer, dynamicDimensionLoader) -> {
             ((SatelliteAccessor) minecraftServer).galacticraft$loadSatellites(dynamicDimensionLoader);
         });
+
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(((player, origin, destination) -> {
+            Container inv = player.galacticraft$getGearInv();
+            ItemStack[] stacks = new ItemStack[inv.getContainerSize()];
+            for(int i = 0; i < inv.getContainerSize(); i++) {
+                stacks[i] = inv.getItem(i);
+            }
+            GearInvPayload payload = new GearInvPayload(player.getId(), stacks);
+            ServerPlayNetworking.send(player, payload);
+        }));
 
         // todo: update celestial body level cache
         DynamicRegistrySetupCallback.EVENT.register(view -> {

--- a/src/main/java/dev/galacticraft/impl/internal/fabric/GalacticraftAPI.java
+++ b/src/main/java/dev/galacticraft/impl/internal/fabric/GalacticraftAPI.java
@@ -36,23 +36,18 @@ import dev.galacticraft.dynamicdimensions.api.event.DynamicDimensionLoadCallback
 import dev.galacticraft.impl.internal.command.GCApiCommands;
 import dev.galacticraft.impl.network.GCApiPackets;
 import dev.galacticraft.impl.network.GCApiServerPacketReceivers;
-import dev.galacticraft.impl.network.s2c.GearInvPayload;
 import dev.galacticraft.impl.universe.BuiltinObjects;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.data.gen.SatelliteChunkGenerator;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistrySetupCallback;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.LevelResource;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -90,16 +85,6 @@ public class GalacticraftAPI implements ModInitializer {
         DynamicDimensionLoadCallback.register((minecraftServer, dynamicDimensionLoader) -> {
             ((SatelliteAccessor) minecraftServer).galacticraft$loadSatellites(dynamicDimensionLoader);
         });
-
-        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(((player, origin, destination) -> {
-            Container inv = player.galacticraft$getGearInv();
-            ItemStack[] stacks = new ItemStack[inv.getContainerSize()];
-            for(int i = 0; i < inv.getContainerSize(); i++) {
-                stacks[i] = inv.getItem(i);
-            }
-            GearInvPayload payload = new GearInvPayload(player.getId(), stacks);
-            ServerPlayNetworking.send(player, payload);
-        }));
 
         // todo: update celestial body level cache
         DynamicRegistrySetupCallback.EVENT.register(view -> {

--- a/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
+++ b/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
@@ -27,6 +27,7 @@ import dev.galacticraft.api.registry.AcidTransformItemRegistry;
 import dev.galacticraft.api.universe.celestialbody.CelestialBody;
 import dev.galacticraft.api.universe.celestialbody.landable.Landable;
 import dev.galacticraft.api.universe.celestialbody.landable.teleporter.CelestialTeleporter;
+import dev.galacticraft.impl.network.s2c.GearInvPayload;
 import dev.galacticraft.mod.Constant;
 import dev.galacticraft.mod.Galacticraft;
 import dev.galacticraft.mod.content.GCCelestialBodies;
@@ -46,6 +47,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -65,6 +67,16 @@ public class GCEventHandlers {
         if (body.type() instanceof Landable landable && player.galacticraft$isCelestialScreenActive() && (player.galacticraft$getCelestialScreenState() == null || player.galacticraft$getCelestialScreenState().canTravel(server.registryAccess(), fromBody, body))) {
             player.galacticraft$closeCelestialScreen();
             ((CelestialTeleporter) landable.teleporter(body.config()).value()).onEnterAtmosphere(server.getLevel(landable.world(body.config())), player, body, fromBody);
+            
+            // Send gear inventory to player
+            Container inv = player.galacticraft$getGearInv();
+            ItemStack[] stacks = new ItemStack[inv.getContainerSize()];
+            for (int i = 0; i < inv.getContainerSize(); i++) {
+                stacks[i] = inv.getItem(i);
+            }
+
+            GearInvPayload payload = new GearInvPayload(player.getId(), stacks);
+            ServerPlayNetworking.send(player, payload);
         } else {
             player.connection.disconnect(Component.translatable(Translations.DimensionTp.INVALID_PACKET));
         }

--- a/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
+++ b/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
@@ -67,7 +67,7 @@ public class GCEventHandlers {
         if (body.type() instanceof Landable landable && player.galacticraft$isCelestialScreenActive() && (player.galacticraft$getCelestialScreenState() == null || player.galacticraft$getCelestialScreenState().canTravel(server.registryAccess(), fromBody, body))) {
             player.galacticraft$closeCelestialScreen();
             ((CelestialTeleporter) landable.teleporter(body.config()).value()).onEnterAtmosphere(server.getLevel(landable.world(body.config())), player, body, fromBody);
-            
+
             // Send gear inventory to player
             Container inv = player.galacticraft$getGearInv();
             ItemStack[] stacks = new ItemStack[inv.getContainerSize()];

--- a/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
+++ b/src/main/java/dev/galacticraft/mod/events/GCEventHandlers.java
@@ -36,6 +36,7 @@ import dev.galacticraft.mod.content.entity.FallingMeteorEntity;
 import dev.galacticraft.mod.misc.footprint.FootprintManager;
 import dev.galacticraft.mod.network.s2c.FootprintRemovedPacket;
 import dev.galacticraft.mod.util.Translations;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -59,6 +60,7 @@ public class GCEventHandlers {
     public static void init() {
         GCSleepEventHandlers.init();
         GCInteractionEventHandlers.init();
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(GCEventHandlers::onPlayerChangeWorld);
         ServerTickEvents.END_WORLD_TICK.register(GCEventHandlers::onWorldTick);
         ServerTickEvents.END_SERVER_TICK.register(GCEventHandlers::onServerTick);
     }
@@ -67,19 +69,21 @@ public class GCEventHandlers {
         if (body.type() instanceof Landable landable && player.galacticraft$isCelestialScreenActive() && (player.galacticraft$getCelestialScreenState() == null || player.galacticraft$getCelestialScreenState().canTravel(server.registryAccess(), fromBody, body))) {
             player.galacticraft$closeCelestialScreen();
             ((CelestialTeleporter) landable.teleporter(body.config()).value()).onEnterAtmosphere(server.getLevel(landable.world(body.config())), player, body, fromBody);
-
-            // Send gear inventory to player
-            Container inv = player.galacticraft$getGearInv();
-            ItemStack[] stacks = new ItemStack[inv.getContainerSize()];
-            for (int i = 0; i < inv.getContainerSize(); i++) {
-                stacks[i] = inv.getItem(i);
-            }
-
-            GearInvPayload payload = new GearInvPayload(player.getId(), stacks);
-            ServerPlayNetworking.send(player, payload);
         } else {
             player.connection.disconnect(Component.translatable(Translations.DimensionTp.INVALID_PACKET));
         }
+    }
+
+    public static void onPlayerChangeWorld(ServerPlayer player, ServerLevel origin, ServerLevel destination) {
+        // Send gear inventory to player
+        Container inv = player.galacticraft$getGearInv();
+        ItemStack[] stacks = new ItemStack[inv.getContainerSize()];
+        for (int i = 0; i < inv.getContainerSize(); i++) {
+            stacks[i] = inv.getItem(i);
+        }
+
+        GearInvPayload packet = new GearInvPayload(player.getId(), stacks);
+        ServerPlayNetworking.send(player, packet);
     }
 
     public static void onWorldTick(ServerLevel level) {


### PR DESCRIPTION
Title.

After player changes dimensions using rocket the custom inventory being reinitialized with no items. Sending proper [GearInvPayload.java](https://github.com/TeamGalacticraft/Galacticraft/blob/main/src/main/java/dev/galacticraft/impl/network/s2c/GearInvPayload.java) packet to player solves the bug.

Closes #580 